### PR TITLE
i2c JS: Fix discrepancy in I2C sample

### DIFF
--- a/examples/i2c-example.js
+++ b/examples/i2c-example.js
@@ -31,7 +31,7 @@ if (cw2015.request()) {
   console.log('Config: 0x' + Buffer(reg).toString('hex'));
   reg = new Buffer([0xff], 'hex');
   console.log('Writing 0x' + Buffer(reg).toString('hex') + ' to config register');
-  cw2015.write_register(8, reg, 1);
+  cw2015.write_register(8, reg);
   reg = cw2015.read_register(8, 1);
   console.log('Config: 0x' + Buffer(reg).toString('hex'));
 

--- a/test/i2c-test.js
+++ b/test/i2c-test.js
@@ -55,7 +55,7 @@ testCase('I2C', function() {
 			console.log('Config: 0x' + Buffer(reg).toString('hex'));
 			reg = new Buffer([0xff], 'hex');
 			console.log('Writing 0x' + Buffer(reg).toString('hex') + ' to config register');
-			cw2015.write_register(8, reg, 1);
+			cw2015.write_register(8, reg);
 			reg = cw2015.read_register(8, 1);
 			console.log('Config: 0x' + Buffer(reg).toString('hex'));
 			assert.isNotNull(reg);


### PR DESCRIPTION
I removed the paramater 'size' in I2C JS functions call but I have noticed that the verification for the number of arguments in the class I2cWrapper is not correct. So I corrected it in artik-sdk guerrit repo (branch 1.1-maintenance), you have to update the library artik-sdk-node in github repo. 